### PR TITLE
Pro 7719

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: tests
+
+# Controls when the action will run.
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ '*' ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - run: npm install
+
+    - run: npm test
+      env:
+        CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Adds
 
 * Supports body style in and out of media queries. Also supports body style applied to indentifiers like ids and classes if they exist on the body tag. 
-Uses the new `[data-apos-refreshable-body]` that exist and replace the body in breakpoint preview in core.
+Uses the new `[data-apos-refreshable-body]` that exists and replace the body in breakpoint preview in core.
 
 ## 1.1.0 (2025-03-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Supports body style in and out of media queries. Also supports body style applied to indentifiers like ids and classes if they exist on the body tag. 
+Uses the new `[data-apos-refreshable-body]` that exist and replace the body in breakpoint preview in core.
+
 ## 1.1.0 (2025-03-19)
 
 ### Adds

--- a/index.js
+++ b/index.js
@@ -143,6 +143,11 @@ const plugin = (opts = {}) => {
           )
         });
 
+        rule.selector = rule.selector.replace(
+          selectorHelper.bodyRegex,
+          conditionalNotSelector
+        );
+
         ruleProcessor.processDeclarations(containerRule, {
           isContainer: true,
           from: helpers.result.opts.from
@@ -150,14 +155,13 @@ const plugin = (opts = {}) => {
 
         // Add container rule after original
         rule.after('\n' + containerRule);
-      }
-
-      if (rule.selector.match(selectorHelper.bodyRegex)) {
-        const selector = rule.selector;
-        rule.selector = selectorHelper.addConditionalToSelectors(
-          selector,
-          conditionalNotSelector
-        );
+      } else {
+        if (rule.selector.match(selectorHelper.bodyRegex)) {
+          rule.selector = selectorHelper.addConditionalToSelectors(
+            rule.selector,
+            [ conditionalNotSelector, containerBodySelector ]
+          );
+        }
       }
 
       rule[processed] = true;

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ const plugin = (opts = {}) => {
         const containerRule = rule.clone({
           source: rule.source,
           from: helpers.result.opts.from,
-          selector: selectorHelper.addConditionalToSelectors(
+          selector: selectorHelper.addTargetsToSelectors(
             rule.selector,
             containerBodySelector
           )
@@ -157,7 +157,7 @@ const plugin = (opts = {}) => {
         rule.after('\n' + containerRule);
       } else {
         if (rule.selector.match(selectorHelper.bodyRegex)) {
-          rule.selector = selectorHelper.addConditionalToSelectors(
+          rule.selector = selectorHelper.addTargetsToSelectors(
             rule.selector,
             [ conditionalNotSelector, containerBodySelector ]
           );
@@ -243,7 +243,7 @@ const plugin = (opts = {}) => {
               from: helpers.result.opts.from
             });
 
-            viewportRule.selector = selectorHelper.addConditionalToSelectors(
+            viewportRule.selector = selectorHelper.addTargetsToSelectors(
               rule.selector,
               conditionalNotSelector
             );

--- a/index.js
+++ b/index.js
@@ -120,8 +120,9 @@ const plugin = (opts = {}) => {
 
       // Do not treat cloned rules already handled
       if (
-        rule.selector.startsWith(conditionalNotSelector) ||
-        rule.selector.startsWith(containerBodySelector)
+        rule.selector.includes(conditionalNotSelector) ||
+        rule.selector.includes(containerBodySelector) ||
+        rule.selector.includes(conditionalSelector)
       ) {
         return;
       }

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const plugin = (opts = {}) => {
   // Create selectors
   const conditionalSelector = `${containerEl}[${modifierAttr}]`;
   const conditionalNotSelector = `${containerEl}:not([${modifierAttr}])`;
+  const containerBodySelector = '[data-apos-refreshable-body]';
 
   // Create utility instances
   const unitConverter = createUnitConverter({ units: options.units });
@@ -48,10 +49,7 @@ const plugin = (opts = {}) => {
     unitConverter,
     ...options
   });
-  const selectorHelper = createSelectorHelper({
-    conditionalNotSelector,
-    modifierAttr
-  });
+  const selectorHelper = createSelectorHelper({ modifierAttr });
 
   // Track processed nodes to avoid duplicates
   const processed = Symbol('processed');
@@ -120,17 +118,30 @@ const plugin = (opts = {}) => {
         return;
       }
 
+      // Do not treat cloned rules already handled
+      if (
+        rule.selector.startsWith(conditionalNotSelector) ||
+        rule.selector.startsWith(containerBodySelector)
+      ) {
+        return;
+      }
+
       // Process rule if it needs conversion
       if (ruleProcessor.needsProcessing(rule)) {
         debugUtils.stats.rulesProcessed++;
         debugUtils.log(`Processing rule: ${rule.selector}`, rule);
 
         // Create container version with converted units
+        // should target [data-apos-refreshable-body]
         const containerRule = rule.clone({
           source: rule.source,
-          from: helpers.result.opts.from
+          from: helpers.result.opts.from,
+          selector: selectorHelper.addConditionalToSelectors(
+            rule.selector,
+            containerBodySelector
+          )
         });
-        containerRule.selector = `${conditionalSelector} ${rule.selector}`;
+
         ruleProcessor.processDeclarations(containerRule, {
           isContainer: true,
           from: helpers.result.opts.from
@@ -138,6 +149,14 @@ const plugin = (opts = {}) => {
 
         // Add container rule after original
         rule.after('\n' + containerRule);
+      }
+
+      if (rule.selector.match(selectorHelper.bodyRegex)) {
+        const selector = rule.selector;
+        rule.selector = selectorHelper.addConditionalToSelectors(
+          selector,
+          conditionalNotSelector
+        );
       }
 
       rule[processed] = true;
@@ -170,15 +189,6 @@ const plugin = (opts = {}) => {
             mediaProcessor.convertToContainerConditions(conditions);
 
           if (containerConditions) {
-
-            // Trying to bypass body selector into container query (not working..)
-            /* const containerQuery = ruleProcessor.getContainerQuery(atRule, { */
-            /*   helpers, */
-            /*   containerConditions, */
-            /*   selectorHelper, */
-            /*   ruleProcessor */
-            /* }); */
-
             const containerQuery = new helpers.AtRule({
               name: 'container',
               params: containerConditions,
@@ -188,9 +198,13 @@ const plugin = (opts = {}) => {
 
             // Clone and process rules for container query - keep selectors clean
             atRule.walkRules(rule => {
-              const containerRule = ruleProcessor.getRuleContainer(rule, {
-                helpers,
-                selectorHelper
+              const containerRule = rule.clone({
+                source: rule.source,
+                from: helpers.result.opts.from,
+                selector: rule.selector.replace(
+                  selectorHelper.bodyRegex,
+                  containerBodySelector
+                )
               });
 
               ruleProcessor.processDeclarations(containerRule, {
@@ -228,7 +242,6 @@ const plugin = (opts = {}) => {
               rule.selector,
               conditionalNotSelector
             );
-            /* console.log('viewportRule.selector', viewportRule.selector); */
 
             rule.replaceWith(viewportRule);
           });

--- a/src/utils/mediaProcessor.js
+++ b/src/utils/mediaProcessor.js
@@ -201,11 +201,11 @@ const createMediaProcessor = ({ transform }) => {
    * Converts an array of media conditions into container query conditions.
    *
    * @param {string[]} conditions - An array of media conditions to convert.
-   * @returns {string[]} An array of container query conditions.
+   * @returns {string|null} A string containing the container query conditions.
    */
   const convertToContainerConditions = (conditions) => {
     if (!conditions.length) {
-      return [];
+      return null;
     }
 
     // Join all conditions with 'and'
@@ -226,7 +226,7 @@ const createMediaProcessor = ({ transform }) => {
       containerQuery = `${containerQuery})`;
     }
 
-    return [ containerQuery.trim() ];
+    return containerQuery.trim();
   };
 
   return {

--- a/src/utils/ruleProcessor.js
+++ b/src/utils/ruleProcessor.js
@@ -126,60 +126,9 @@ const createRuleProcessor = ({ unitConverter }) => {
     return { hasFixedPosition };
   };
 
-  // Not working (cannot nest container query inside another rule)
-  const getContainerQuery = (atRule, {
-    helpers, containerConditions, selectorHelper, ruleProcessor
-  }) => {
-    const containerQuery = new helpers.AtRule({
-      name: 'container',
-      params: containerConditions,
-      source: atRule.source,
-      from: helpers.result.opts.from
-    });
-
-    // Clone and process rules for container query - keep selectors clean
-    atRule.walkRules(rule => {
-      const [ bodySelector ] = rule.selector.match(selectorHelper.bodyRegexFull) || [];
-      const subSelector = bodySelector && rule.selector.replace(bodySelector, '').trim();
-      const bodyRule = bodySelector && rule.clone({
-        source: rule.source,
-        from: helpers.result.opts.from,
-        selector: bodySelector
-      });
-
-      const containerRule = rule.clone({
-        source: rule.source,
-        from: helpers.result.opts.from,
-        ...subSelector && { selector: subSelector }
-      });
-
-      ruleProcessor.processDeclarations(containerRule, {
-        isContainer: true,
-        from: helpers.result.opts.from
-      });
-
-      containerRule.raws.before = '\n  ';
-      containerRule.raws.after = '\n  ';
-      containerRule.walkDecls(decl => {
-        decl.raws.before = '\n    ';
-      });
-
-      containerQuery.append(containerRule);
-      if (bodyRule) {
-        bodyRule.append(containerQuery);
-        return bodyRule;
-      }
-
-      return containerQuery;
-    });
-
-    return containerQuery;
-  };
-
   return {
     needsProcessing,
-    processDeclarations,
-    getContainerQuery
+    processDeclarations
   };
 };
 

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -1,53 +1,54 @@
 
-const createSelectorHelper = ({ conditionalNotSelector, modifierAttr }) => {
-  const containerSelector = '[data-apos-refreshable]';
-  const bodyRegex = /^body|^html\s+body|^html\s*>\s*body/;
+const createSelectorHelper = ({ modifierAttr }) => {
+  const bodyRegex = /^body|^html.*\s+body|^html.*\s*>\s*body/;
   const bodyRegexFull = /(^body|^html\s+body|^html\s*>\s*body)[.#\w\d[\]"-=:]*/;
 
-  const addConditionalToSelectors = (selector, conditionalNotSelector) => {
-    const conditionalSelector = selector
+  const addConditionalToSelectors = (
+    selector,
+    conditionalSelector,
+    returnArray = false
+  ) => {
+    const updatedSelector = selector
       .split(',')
-      .filter(part => !part.trim() || !part.trim().match(bodyRegex))
-      .map(part => `${conditionalNotSelector} ${part.trim()}`);
+      .reduce((acc, part) => {
+        const trimmed = part.trim();
+        if (!trimmed.match(bodyRegex)) {
+          acc.push(`${conditionalSelector} ${trimmed}`);
+        }
+        const bodyLevelSelector = getLevelBodySelector(trimmed, conditionalSelector);
+        if (bodyLevelSelector) {
+          acc.push(bodyLevelSelector);
+        }
+        return acc;
+      }, []);
 
-    const bodyLevelSelector = addBodyLevelSelector(selector);
-    if (bodyLevelSelector) {
-      conditionalSelector.push(bodyLevelSelector);
-    }
-
-    return conditionalSelector.join(',\n  ');
+    return returnArray ? updatedSelector : updatedSelector.join(',\n  ');
   };
 
-  const bodySelectorToContainer = (selector) => {
-    const trimmed = selector.trim();
-    if (!trimmed.match(bodyRegex)) {
-      return trimmed;
-    }
-    return trimmed.replace(bodyRegex, containerSelector);
-  };
-
-  const addBodyLevelSelector = (selector) => {
-    selector = selector.trim();
+  const getLevelBodySelector = (selector, conditionalSelector) => {
     if (selector.match(bodyRegex)) {
       selector = selector.replace(bodyRegex, '');
 
+      // Selector is a body without identifiers, we put style in the body directly
       if (!selector) {
-        return conditionalNotSelector;
+        return conditionalSelector;
       }
     }
 
+    // If selector starts by an identifier that is not a tag, we put it next to the body
+    // in case the body has this identifier
     const noTagSelector = selector.match(/^\.|^#|^\[|^:/);
     if (noTagSelector) {
-      return `${conditionalNotSelector}${selector}`;
+      return `${conditionalSelector}${selector}`;
     }
+
+    return null;
   };
 
   return {
-    containerSelector,
     bodyRegex,
     bodyRegexFull,
-    addConditionalToSelectors,
-    bodySelectorToContainer
+    addConditionalToSelectors
   };
 };
 

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -1,0 +1,53 @@
+const containerSelector = '[data-apos-refreshable]';
+
+const createSelectorHelper = ({ conditionalNotSelector, modifierAttr }) => {
+  const bodyRegex = /^body|^html\s+body|^html\s*>\s*body/;
+  const bodyRegexFull = /(^body|^html\s+body|^html\s*>\s*body)[.#\w\d[\]"-=:]*/;
+
+  const addConditionalToSelectors = (selector, conditionalNotSelector) => {
+    let conditionalSelector = selector
+      .split(',')
+      .map(part => `${conditionalNotSelector} ${part.trim()}`)
+      .join(',\n  ');
+
+    const bodyLevelSelector = addBodyLevelSelector(selector);
+    if (bodyLevelSelector) {
+      conditionalSelector += `, ${bodyLevelSelector}`;
+    }
+
+    return conditionalSelector;
+  };
+
+  const bodySelectorToContainer = (selector) => {
+    const trimmed = selector.trim();
+    if (!trimmed.match(bodyRegex)) {
+      return trimmed;
+    }
+    return trimmed.replace(bodyRegex, containerSelector);
+  };
+
+  const addBodyLevelSelector = (selector) => {
+    selector = selector.trim();
+    if (selector.match(bodyRegex)) {
+      selector = selector.replace(bodyRegex, '');
+
+      if (!selector) {
+        return conditionalNotSelector;
+      }
+    }
+
+    const noTagSelector = selector.match(/^\.|^#|^\[|^:/);
+    if (noTagSelector) {
+      return `${conditionalNotSelector}${selector}`;
+    }
+  };
+
+  return {
+    bodyRegex,
+    bodyRegexFull,
+    addConditionalToSelectors,
+    bodySelectorToContainer
+  };
+};
+
+module.exports = createSelectorHelper;

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -3,14 +3,14 @@ const createSelectorHelper = ({ modifierAttr }) => {
   const bodyRegex = /^body|^html.*\s+body|^html.*\s*>\s*body/;
   const bodyRegexFull = /(^body|^html\s+body|^html\s*>\s*body)[.#\w\d[\]"-=:]*/;
 
-  const addConditionalToSelectors = (
+  const addTargetsToSelectors = (
     selector,
-    conditionalSelector,
+    target,
     returnArray = false
   ) => {
-    if (Array.isArray(conditionalSelector)) {
-      const updatedSelector = conditionalSelector.reduce((acc, cur) => {
-        const updated = addConditionalToSelectors(selector, cur, true);
+    if (Array.isArray(target)) {
+      const updatedSelector = target.reduce((acc, cur) => {
+        const updated = addTargetsToSelectors(selector, cur, true);
         return [ ...acc, ...updated ];
       }, []);
 
@@ -22,9 +22,9 @@ const createSelectorHelper = ({ modifierAttr }) => {
       .reduce((acc, part) => {
         const trimmed = part.trim();
         if (!trimmed.match(bodyRegex)) {
-          acc.push(`${conditionalSelector} ${trimmed}`);
+          acc.push(`${target} ${trimmed}`);
         }
-        const bodyLevelSelector = getLevelBodySelector(trimmed, conditionalSelector);
+        const bodyLevelSelector = getBodyLevelSelector(trimmed, target);
         if (bodyLevelSelector) {
           acc.push(bodyLevelSelector);
         }
@@ -34,13 +34,13 @@ const createSelectorHelper = ({ modifierAttr }) => {
     return returnArray ? updatedSelector : updatedSelector.join(',\n  ');
   };
 
-  const getLevelBodySelector = (selector, conditionalSelector) => {
+  const getBodyLevelSelector = (selector, target) => {
     if (selector.match(bodyRegex)) {
       selector = selector.replace(bodyRegex, '');
 
       // Selector is a body without identifiers, we put style in the body directly
       if (!selector) {
-        return conditionalSelector;
+        return target;
       }
     }
 
@@ -48,7 +48,7 @@ const createSelectorHelper = ({ modifierAttr }) => {
     // in case the body has this identifier
     const noTagSelector = selector.match(/^\.|^#|^\[|^:/);
     if (noTagSelector) {
-      return `${conditionalSelector}${selector}`;
+      return `${target}${selector}`;
     }
 
     return null;
@@ -57,7 +57,7 @@ const createSelectorHelper = ({ modifierAttr }) => {
   return {
     bodyRegex,
     bodyRegexFull,
-    addConditionalToSelectors
+    addTargetsToSelectors
   };
 };
 

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -1,21 +1,21 @@
-const containerSelector = '[data-apos-refreshable]';
 
 const createSelectorHelper = ({ conditionalNotSelector, modifierAttr }) => {
+  const containerSelector = '[data-apos-refreshable]';
   const bodyRegex = /^body|^html\s+body|^html\s*>\s*body/;
   const bodyRegexFull = /(^body|^html\s+body|^html\s*>\s*body)[.#\w\d[\]"-=:]*/;
 
   const addConditionalToSelectors = (selector, conditionalNotSelector) => {
-    let conditionalSelector = selector
+    const conditionalSelector = selector
       .split(',')
-      .map(part => `${conditionalNotSelector} ${part.trim()}`)
-      .join(',\n  ');
+      .filter(part => !part.trim() || !part.trim().match(bodyRegex))
+      .map(part => `${conditionalNotSelector} ${part.trim()}`);
 
     const bodyLevelSelector = addBodyLevelSelector(selector);
     if (bodyLevelSelector) {
-      conditionalSelector += `, ${bodyLevelSelector}`;
+      conditionalSelector.push(bodyLevelSelector);
     }
 
-    return conditionalSelector;
+    return conditionalSelector.join(',\n  ');
   };
 
   const bodySelectorToContainer = (selector) => {
@@ -43,6 +43,7 @@ const createSelectorHelper = ({ conditionalNotSelector, modifierAttr }) => {
   };
 
   return {
+    containerSelector,
     bodyRegex,
     bodyRegexFull,
     addConditionalToSelectors,

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -1,7 +1,6 @@
 
 const createSelectorHelper = ({ modifierAttr }) => {
   const bodyRegex = /^body|^html.*\s+body|^html.*\s*>\s*body/;
-  const bodyRegexFull = /(^body|^html\s+body|^html\s*>\s*body)[.#\w\d[\]"-=:]*/;
 
   const addTargetsToSelectors = (
     selector,
@@ -56,7 +55,6 @@ const createSelectorHelper = ({ modifierAttr }) => {
 
   return {
     bodyRegex,
-    bodyRegexFull,
     addTargetsToSelectors
   };
 };

--- a/src/utils/selectorHelper.js
+++ b/src/utils/selectorHelper.js
@@ -8,6 +8,15 @@ const createSelectorHelper = ({ modifierAttr }) => {
     conditionalSelector,
     returnArray = false
   ) => {
+    if (Array.isArray(conditionalSelector)) {
+      const updatedSelector = conditionalSelector.reduce((acc, cur) => {
+        const updated = addConditionalToSelectors(selector, cur, true);
+        return [ ...acc, ...updated ];
+      }, []);
+
+      return updatedSelector.join(',\n  ');
+    }
+
     const updatedSelector = selector
       .split(',')
       .reduce((acc, part) => {

--- a/test/index.js
+++ b/test/index.js
@@ -38,9 +38,9 @@ async function run(plugin, input, output, opts = {}) {
     console.log('Input:');
     console.log(input);
     console.log('\nExpected Output (Formatted):');
-    console.log(await formatCSS(output));
-    console.log('\nActual Output (Formatted):');
-    console.log(await formatCSS(result.css));
+    console.log(output);
+    console.log('\nActual Output:');
+    console.log(result.css);
 
     throw error;
   }
@@ -62,11 +62,13 @@ describe('postcss-viewport-to-container-toggle additional features', () => {
   line-height: calc(1.5 + 1vh);
   letter-spacing: 0.5vmin;
 }
-body[data-breakpoint-preview-mode] .text {
+[data-apos-refreshable-body] .text,
+[data-apos-refreshable-body].text {
   font-size: calc(16px + 2cqw);
   line-height: calc(1.5 + 1cqh);
   letter-spacing: 0.5cqi;
-}`.trim();
+}
+`;
 
       await run(plugin, input, output, opts);
     });
@@ -82,10 +84,11 @@ body[data-breakpoint-preview-mode] .text {
   font-size: clamp(1rem, 2vw + 1rem, 3rem);
   line-height: clamp(1.2, calc(1 + 2vh), 1.8);
 }
-body[data-breakpoint-preview-mode] .fluid-text {
+[data-apos-refreshable-body] .fluid-text,
+[data-apos-refreshable-body].fluid-text {
   font-size: clamp(1rem, 1rem + 2cqw, 3rem);
   line-height: clamp(1.2, calc(1 + 2cqh), 1.8);
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -101,10 +104,11 @@ body[data-breakpoint-preview-mode] .fluid-text {
   color: red;
   font-size: 2vw;
 }
-body[data-breakpoint-preview-mode] .foo {
+[data-apos-refreshable-body] .foo,
+[data-apos-refreshable-body].foo {
   color: red;
   font-size: 2cqw;
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -118,9 +122,10 @@ body[data-breakpoint-preview-mode] .foo {
 .decimals {
   font-size: 2.75vw;
 }
-body[data-breakpoint-preview-mode] .decimals {
+[data-apos-refreshable-body] .decimals,
+[data-apos-refreshable-body].decimals {
   font-size: 2.75cqw;
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -134,9 +139,10 @@ body[data-breakpoint-preview-mode] .decimals {
 .zero-test {
   font-size: 0vw;
 }
-body[data-breakpoint-preview-mode] .zero-test {
+[data-apos-refreshable-body] .zero-test,
+[data-apos-refreshable-body].zero-test{
   font-size: 0cqw;
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -150,9 +156,10 @@ body[data-breakpoint-preview-mode] .zero-test {
 .nested-calc {
   font-size: clamp(1rem, calc(50vw - 2rem), calc(100vh - 4rem));
 }
-body[data-breakpoint-preview-mode] .nested-calc {
+[data-apos-refreshable-body] .nested-calc,
+[data-apos-refreshable-body].nested-calc {
   font-size: clamp(1rem, calc(50cqw - 2rem), calc(100cqh - 4rem));
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -181,7 +188,8 @@ body[data-breakpoint-preview-mode] {
   width: 100vw;
   height: 60px;
 }
-body[data-breakpoint-preview-mode] .fixed-header {
+[data-apos-refreshable-body] .fixed-header,
+[data-apos-refreshable-body].fixed-header {
   position: sticky;
   --container-top: 0;
   top: var(--container-top);
@@ -189,7 +197,7 @@ body[data-breakpoint-preview-mode] .fixed-header {
   left: var(--container-left);
   width: 100cqw;
   height: 60px;
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -209,7 +217,8 @@ body[data-breakpoint-preview-mode] {
   contain: layout;
 }
 @media (min-width: 768px) {
-  body:not([data-breakpoint-preview-mode]) .fixed-in-media {
+  body:not([data-breakpoint-preview-mode]) .fixed-in-media,
+  body:not([data-breakpoint-preview-mode]).fixed-in-media {
     position: fixed;
     top: 0;
     width: 100vw;
@@ -222,7 +231,8 @@ body[data-breakpoint-preview-mode] {
     top: var(--container-top);
     width: 100cqw;
   }
-}`.trim();
+}
+`;
 
       await run(plugin, input, output, opts);
     });
@@ -245,12 +255,13 @@ body[data-breakpoint-preview-mode] {
   min-height: 100svh;
   max-width: 100lvw;
 }
-body[data-breakpoint-preview-mode] .dynamic {
+[data-apos-refreshable-body] .dynamic,
+[data-apos-refreshable-body].dynamic {
   height: 100cqh;
   width: 100cqw;
   min-height: 100cqh;
   max-width: 100cqw;
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -266,10 +277,11 @@ body[data-breakpoint-preview-mode] .dynamic {
   margin: calc(10px + 2vw - 1vh);
   padding: calc((100vw - 20px) / 2 + 1vmin);
 }
-body[data-breakpoint-preview-mode] .complex {
+[data-apos-refreshable-body] .complex,
+[data-apos-refreshable-body].complex {
   margin: calc(10px + 2cqw - 1cqh);
   padding: calc((100cqw - 20px) / 2 + 1cqmin);
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -286,7 +298,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (width <= 1024px) {
-  body:not([data-breakpoint-preview-mode]) .single-operator {
+  body:not([data-breakpoint-preview-mode]) .single-operator,
+  body:not([data-breakpoint-preview-mode]).single-operator {
     width: 100vw;
   }
 }
@@ -294,7 +307,7 @@ body[data-breakpoint-preview-mode] .complex {
   .single-operator {
     width: 100cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -308,7 +321,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (width >= 240px) {
-  body:not([data-breakpoint-preview-mode]) .single-operator {
+  body:not([data-breakpoint-preview-mode]) .single-operator,
+  body:not([data-breakpoint-preview-mode]).single-operator {
     width: 100vw;
   }
 }
@@ -316,7 +330,7 @@ body[data-breakpoint-preview-mode] .complex {
   .single-operator {
     width: 100cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -330,7 +344,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (width<=1024px) {
-  body:not([data-breakpoint-preview-mode]) .poorly-formatted {
+  body:not([data-breakpoint-preview-mode]) .poorly-formatted,
+  body:not([data-breakpoint-preview-mode]).poorly-formatted {
     width: 100vw;
   }
 }
@@ -338,7 +353,7 @@ body[data-breakpoint-preview-mode] .complex {
   .poorly-formatted {
     width: 100cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -353,7 +368,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (min-width: 500px) and (width<=1024px) {
-  body:not([data-breakpoint-preview-mode]) .combined-operator {
+  body:not([data-breakpoint-preview-mode]) .combined-operator,
+  body:not([data-breakpoint-preview-mode]).combined-operator {
     width: 90vw;
     margin: 0 5vw;
   }
@@ -363,7 +379,7 @@ body[data-breakpoint-preview-mode] .complex {
     width: 90cqw;
     margin: 0 5cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -381,7 +397,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (240px <= width <= 1024px) {
-  body:not([data-breakpoint-preview-mode]) .range {
+  body:not([data-breakpoint-preview-mode]) .range,
+  body:not([data-breakpoint-preview-mode]).range {
     width: 90vw;
     margin: 0 5vw;
   }
@@ -391,7 +408,7 @@ body[data-breakpoint-preview-mode] .complex {
     width: 90cqw;
     margin: 0 5cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -405,7 +422,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media screen and (min-width: 768px), print {
-  body:not([data-breakpoint-preview-mode]) .mixed {
+  body:not([data-breakpoint-preview-mode]) .mixed,
+  body:not([data-breakpoint-preview-mode]).mixed {
     width: 80vw;
   }
 }
@@ -413,7 +431,7 @@ body[data-breakpoint-preview-mode] .complex {
   .mixed {
     width: 80cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -428,7 +446,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (orientation: landscape) and (min-width: 768px) {
-  body:not([data-breakpoint-preview-mode]) .landscape {
+  body:not([data-breakpoint-preview-mode]) .landscape,
+  body:not([data-breakpoint-preview-mode]).landscape {
     height: 100vh;
     width: 100vw;
   }
@@ -438,7 +457,7 @@ body[data-breakpoint-preview-mode] .complex {
     height: 100cqh;
     width: 100cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -453,7 +472,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (orientation: landscape) {
-  body:not([data-breakpoint-preview-mode]) .landscape {
+  body:not([data-breakpoint-preview-mode]) .landscape,
+  body:not([data-breakpoint-preview-mode]).landscape {
     height: 100vh;
     width: 100vw;
   }
@@ -463,7 +483,7 @@ body[data-breakpoint-preview-mode] .complex {
     height: 100cqh;
     width: 100cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -478,7 +498,10 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (min-width: 320px) {
-  body:not([data-breakpoint-preview-mode]) .mobile { width: 90vw; }
+  body:not([data-breakpoint-preview-mode]) .mobile, 
+  body:not([data-breakpoint-preview-mode]).mobile { 
+    width: 90vw; 
+  }
 }
 @container (min-width: 320px) {
   .mobile {
@@ -486,13 +509,16 @@ body[data-breakpoint-preview-mode] .complex {
   }
 }
 @media (min-width: 768px) {
-  body:not([data-breakpoint-preview-mode]) .tablet { width: 80vw; }
+  body:not([data-breakpoint-preview-mode]) .tablet,
+  body:not([data-breakpoint-preview-mode]).tablet {
+    width: 80vw; 
+  }
 }
 @container (min-width: 768px) {
   .tablet {
     width: 80cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -512,7 +538,8 @@ body[data-breakpoint-preview-mode] .complex {
       const output = `
 @media screen {
   @media (min-width: 768px) {
-    body:not([data-breakpoint-preview-mode]) .nested {
+    body:not([data-breakpoint-preview-mode]) .nested, 
+    body:not([data-breakpoint-preview-mode]).nested {
       width: 80vw;
     }
   }
@@ -521,7 +548,7 @@ body[data-breakpoint-preview-mode] .complex {
   .nested {
     width: 80cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -542,7 +569,7 @@ body[data-breakpoint-preview-mode] .complex {
   .print-only {
     width: 50vw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -564,7 +591,8 @@ body[data-breakpoint-preview-mode] .complex {
 }`;
       const output = `
 @media (min-width: 500px) {
-  body:not([data-breakpoint-preview-mode]) .transformed {
+  body:not([data-breakpoint-preview-mode]) .transformed,
+  body:not([data-breakpoint-preview-mode]).transformed {
     width: 50vw;
   }
 }
@@ -572,12 +600,171 @@ body[data-breakpoint-preview-mode] .complex {
   .transformed {
     width: 50cqw;
   }
-}`.trim();
+}`;
 
       await run(plugin, input, output, {
         ...opts,
         transform: customTransform
       });
+    });
+  });
+
+  describe('Body level style to container compatibility', () => {
+    it('should conserve body level styles when breakpoint preview is off (in media queries)', async () => {
+      const input = `
+@media (min-width: 768px) {
+  body {
+    font-size: 16px;
+  }
+  html.toto body.my-body {
+    font-size: 16px;
+  }
+  html#foo body.my-body {
+    font-size: 16px;
+  }
+  html>body#my-body.my-body {
+    font-size: 16px;
+  }
+  #my-body {
+    font-size: 16px;
+  }
+  .my-body {
+    font-size: 16px;
+  }
+  body.my-body p {
+    color: green;
+  }
+  body#my-body.my-body p {
+    color: green;
+  }
+  #my-body p {
+    color: green;
+  }
+  .my-body p {
+    color: green;
+  }
+}
+`;
+
+      const output = `
+@media (min-width: 768px) {
+  body:not([data-breakpoint-preview-mode]) {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode]).my-body {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode]).my-body {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode])#my-body.my-body {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode]) #my-body,
+  body:not([data-breakpoint-preview-mode])#my-body {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode]) .my-body,
+  body:not([data-breakpoint-preview-mode]).my-body {
+    font-size: 16px;
+  }
+  body:not([data-breakpoint-preview-mode]).my-body p {
+    color: green;
+  }
+  body:not([data-breakpoint-preview-mode])#my-body.my-body p {
+    color: green;
+  }
+  body:not([data-breakpoint-preview-mode]) #my-body p,
+  body:not([data-breakpoint-preview-mode])#my-body p {
+    color: green;
+  }
+  body:not([data-breakpoint-preview-mode]) .my-body p,
+  body:not([data-breakpoint-preview-mode]).my-body p {
+    color: green;
+  }
+}
+@container (min-width: 768px) {
+  [data-apos-refreshable-body] {
+    font-size: 16px;
+  }
+  [data-apos-refreshable-body].my-body {
+    font-size: 16px;
+  }
+  [data-apos-refreshable-body].my-body {
+    font-size: 16px;
+  }
+  [data-apos-refreshable-body]#my-body.my-body {
+    font-size: 16px;
+  }
+  #my-body {
+    font-size: 16px;
+  }
+  .my-body {
+    font-size: 16px;
+  }
+  [data-apos-refreshable-body].my-body p {
+    color: green;
+  }
+  [data-apos-refreshable-body]#my-body.my-body p {
+    color: green;
+  }
+  #my-body p {
+    color: green;
+  }
+  .my-body p {
+    color: green;
+  }
+}`;
+
+      await run(plugin, input, output, opts);
+    });
+
+    it('should move style from body to container fake body out of media queries', async () => {
+      const input = `
+.toto div {
+  font-size: 16px;
+}
+body.my-body .container {
+  width: 50vw;
+}
+.my-body .container p {
+  width: 50vw;
+}
+.toto {
+  font-size: 16px;
+  width: 50vw;
+}
+`;
+
+      const output = `
+.toto div {
+  font-size: 16px;
+}
+body:not([data-breakpoint-preview-mode]).my-body .container {
+  width: 50vw;
+}
+[data-apos-refreshable-body].my-body .container {
+  width: 50cqw;
+}
+.my-body .container p {
+  width: 50vw;
+}
+[data-apos-refreshable-body] .my-body .container p,
+  [data-apos-refreshable-body].my-body .container p {
+  width: 50cqw;
+}
+.toto {
+  font-size: 16px;
+  width: 50vw;
+}
+[data-apos-refreshable-body] .toto,
+  [data-apos-refreshable-body].toto {
+  font-size: 16px;
+  width: 50cqw;
+}
+`;
+
+      await run(plugin, input, output, opts);
     });
   });
 
@@ -591,7 +778,8 @@ body[data-breakpoint-preview-mode] .complex {
       const input = '.debug { width: 100vw; }';
       const output = `
 .debug { width: 100vw; }
-body[data-breakpoint-preview-mode] .debug { width: 100cqw; }`.trim();
+[data-apos-refreshable-body] .debug,
+[data-apos-refreshable-body].debug { width: 100cqw; }`;
 
       await run(plugin, input, output, debugOpts);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -231,8 +231,7 @@ body[data-breakpoint-preview-mode] {
     top: var(--container-top);
     width: 100cqw;
   }
-}
-`;
+}`;
 
       await run(plugin, input, output, opts);
     });
@@ -746,6 +745,7 @@ body:not([data-breakpoint-preview-mode]).my-body .container {
 [data-apos-refreshable-body].my-body .container {
   width: 50cqw;
 }
+
 .my-body .container p {
   width: 50vw;
 }
@@ -761,6 +761,49 @@ body:not([data-breakpoint-preview-mode]).my-body .container {
   [data-apos-refreshable-body].toto {
   font-size: 16px;
   width: 50cqw;
+}
+`;
+
+      await run(plugin, input, output, opts);
+    });
+
+    it('should transform body selectors to work with and without mobile preview without specific units', async () => {
+      const input = `
+body {
+  color: purple;
+}
+
+html body.my-body {
+  background-color: red;
+}
+
+html>body#my-body.my-body {
+  color: green;
+}
+
+html.toto#tutu >   body#foo.bar {
+  color: green;
+}
+`;
+      const output = `
+body:not([data-breakpoint-preview-mode]),
+[data-apos-refreshable-body] {
+  color: purple;
+}
+
+body:not([data-breakpoint-preview-mode]).my-body,
+[data-apos-refreshable-body].my-body {
+  background-color: red;
+}
+
+body:not([data-breakpoint-preview-mode])#my-body.my-body,
+[data-apos-refreshable-body]#my-body.my-body {
+  color: green;
+}
+
+body:not([data-breakpoint-preview-mode])#foo.bar,
+[data-apos-refreshable-body]#foo.bar {
+  color: green;
 }
 `;
 


### PR DESCRIPTION
[PRO-7719](https://linear.app/apostrophecms/issue/PRO-7719/breakpoint-preview-uses-data-attributes-on-body)

## Summary

Improve this plugin too:
- Support css applied to style out and inside media queries (with and without `body` tag). 
if it uses only the body tag we change the code like so:
(also works with selectors like: `html body`, `html#id.class > body`, `html>body`):
```css
body { color: blue; }

```
to
```css
body:not([data-breakpoint-preview-mode]),
[data-apos-refreshable-body] {
  color: blue;
}
```
- Styles out of media queries but needing processing because viewport units have been updated too:
```css
.toto {
  font-size: 16px;
  width: 50vw;
}
```
to
```css
.toto {
  width: 50vw;
}
[data-apos-refreshable-body] .toto,
  [data-apos-refreshable-body].toto { // This way if the class exist on body the style is working
  width: 50cqw;
}
```
- Finally reworked media queries style slightly:
```css
@media (min-width: 768px) {
  html.toto body.my-body {
    font-size: 16px;
  }
  .my-class {
    font-size: 16px;
  }
  body.my-body p {
    color: green;
  }
  #my-id p {
    color: green;
  }
}
```
to
```css
@media (min-width: 768px) {
  body:not([data-breakpoint-preview-mode]) {
    font-size: 16px;
  }
  body:not([data-breakpoint-preview-mode]).my-body {
    font-size: 16px;
  }
  body:not([data-breakpoint-preview-mode]) .my-class,
  body:not([data-breakpoint-preview-mode]).my-class {
    font-size: 16px;
  }
  body:not([data-breakpoint-preview-mode]).my-body p {
    color: green;
  }
  body:not([data-breakpoint-preview-mode]) #my-id p,
  body:not([data-breakpoint-preview-mode])#my-id p {
    color: green;
  }
}
@container (min-width: 768px) {
  [data-apos-refreshable-body] {
    font-size: 16px;
  }
  [data-apos-refreshable-body].my-body {
    font-size: 16px;
  }
  .my-class {
    font-size: 16px;
  }
  [data-apos-refreshable-body].my-body p {
    color: green;
  }
  #my-id p {
    color: green;
  }
}
```

While probable still not perfect yet, it should covert a good amount of issues our customers / users are facing right now.

## What are the specific steps to test this change?
⚠️ Should be reviewed with the [core PR](https://github.com/apostrophecms/apostrophe/pull/4961).

- Styles described in the ticket should work and be responsive.
- Styles applied to body out of media queries should work in and out breakpoint preview.

## What kind of change does this PR introduce?

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
